### PR TITLE
Pass the checks list to the pipes CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,3 +7,5 @@ on:
 jobs:
     pipes:
         uses: dragunovartem99/pipes/.github/workflows/ci.yaml@main
+        with:
+            checks: '["format:check", "types:check", "lint:check", "test"]'


### PR DESCRIPTION
pipes CI now requires an explicit `checks` input; main's caller predates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1cS62D8H2S2NdxoXD6EB1