### PR TITLE
Add the npm downloads badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Vue PGN Viewer
 
 <a href="https://dragunovartem99.github.io/vue-pgn-viewer" target="_blank"><img alt="Static Badge" src="https://img.shields.io/badge/Watch_Live_Demo-red"></a>
+<img alt="NPM Downloads" src="https://img.shields.io/npm/d18m/vue-pgn-viewer?color=blue">
 <img alt="NPM Version" src="https://img.shields.io/npm/v/vue-pgn-viewer?color=orange">
 
 Vue 3 adapter for the official [**Lichess PGN Viewer**](https://github.com/lichess-org/pgn-viewer)


### PR DESCRIPTION
Adds the npm downloads badge (`d18m`) above the version badge, matching the README of `html-diagram`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JthsKPVD3NW7Lyn78yrjkB